### PR TITLE
fixed repo name conventions

### DIFF
--- a/docker-images/base/patch/perceval-git-loc.py.diff
+++ b/docker-images/base/patch/perceval-git-loc.py.diff
@@ -72,7 +72,7 @@ index 9d7ca5b..5b93eed 100644
  class EmptyRepositoryError(RepositoryError):
      """Exception raised when a repository is empty"""
 diff --git a/perceval/utils.py b/perceval/utils.py
-index a7f5f3b..41a61c6 100644
+index a7f5f3b..03bc7a6 100644
 --- a/perceval/utils.py
 +++ b/perceval/utils.py
 @@ -26,10 +26,13 @@
@@ -99,7 +99,7 @@ index a7f5f3b..41a61c6 100644
  
  
  logger = logging.getLogger(__name__)
-@@ -271,3 +275,391 @@ def xml_to_dict(raw_xml):
+@@ -271,3 +275,406 @@ def xml_to_dict(raw_xml):
      d = node_to_dict(tree)
  
      return d
@@ -135,9 +135,9 @@ index a7f5f3b..41a61c6 100644
 +    @property
 +    def org_name(self):
 +        parser = urlparse(self.git_url)
-+        org_name = self._build_org_name(parser.netloc)
++        org_name = self._build_org_name(parser.netloc, False)
 +        if self.is_gitsource(parser.netloc):
-+            org_name = self._build_org_name(parser.path)
++            org_name = self._build_org_name(parser.path, True)
 +        return org_name
 +
 +    @property
@@ -147,16 +147,17 @@ index a7f5f3b..41a61c6 100644
 +
 +    def _build_repo_name(self, path, org_name):
 +        sanitize_path = self.sanitize_url(path)
-+        sanitize_path = sanitize_path.replace(org_name + '/', '')
++        if org_name in sanitize_path:
++            sanitize_path = sanitize_path.replace('{0}/'.format(self.org_name), '')
 +        if not self.follow_hierarchy:
-+            return sanitize_path.replace('/', '_')
++            return sanitize_path.replace('/', '-').replace('_', '-')
 +        return sanitize_path
 +
-+    def _build_org_name(self, path):
++    def _build_org_name(self, path, git_source):
 +        sanitize_path = self.sanitize_url(path)
-+        if '.' in sanitize_path:
++        if not git_source:
 +            return sanitize_path.split('.')[1]
-+        return sanitize_path.split('/')[1]
++        return sanitize_path.split('/')[0]
 +
 +    @staticmethod
 +    def __get_processed_uri(uri):
@@ -175,8 +176,8 @@ index a7f5f3b..41a61c6 100644
 +    def __get_git_repo_path(self):
 +        base_path = self.__get_base_path()
 +        if self.follow_hierarchy:
-+            return os.path.join(base_path, self.org_name + self.repo_name)
-+        return os.path.join(base_path, self.org_name + self.repo_name)
++            return os.path.join(base_path, '{0}/{1}'.format(self.org_name, self.repo_name))
++        return os.path.join(base_path, '{0}-{1}'.format(self.org_name, self.repo_name))
 +
 +    @staticmethod
 +    def is_gitsource(host):
@@ -189,9 +190,10 @@ index a7f5f3b..41a61c6 100644
 +    @staticmethod
 +    def sanitize_url(path):
 +        if path.startswith('/r/'):
-+            path = path.replace('/r', '')
++            path = path.replace('/r/', '')
 +        elif path.startswith('/gerrit/'):
-+            path = path.replace('/gerrit', '')
++            path = path.replace('/gerrit/', '')
++        path = path.lstrip('/')
 +        return path
 +
 +    @staticmethod
@@ -415,17 +417,30 @@ index a7f5f3b..41a61c6 100644
 +        return stats_data
 +
 +    def _write_json_file(self, data, path, filename):
-+        path = os.path.join(path, filename)
-+        with open(path, 'w') as f:
-+            f.write(json.dumps(data, indent=4))
-+        f.close()
++        try:
++            path = os.path.join(path, filename)
++            with open(path, 'w') as f:
++                f.write(json.dumps(data, indent=4))
++            f.close()
++        except Exception as je:
++            logger.error("cache file write error %s", str(je))
++        finally:
++            pass
 +
 +    def _read_json_file(self, path, filename):
-+        path = os.path.join(path, filename)
-+        with open(path, 'r') as f:
-+            data = f.read()
-+        f.close()
-+        return json.loads(data)
++        error = None
++        try:
++            path = os.path.join(path, filename)
++            with open(path, 'r') as f:
++                data = f.read()
++            f.close()
++            return json.loads(data)
++        except Exception as je:
++            logger.error("cache file write error %s", str(je))
++            error = True
++        finally:
++            if error:
++                return self._build_empty_stats_data()
 +
 +    def _load_cache(self):
 +        path = os.path.join(self.__get_cache_path(), self.cache_file_name)
@@ -440,7 +455,7 @@ index a7f5f3b..41a61c6 100644
 +            self._cache = self._read_json_file(path=self.__get_cache_path(),
 +                                               filename=self.cache_file_name)
 +
-+            if self.repo_name not in self._cache:
++            if self.repo_name not in self._cache.keys():
 +                self._cache.update(self._build_empty_stats_data())
 +                self._write_json_file(data=self._cache,
 +                                      path=self.__get_cache_path(),


### PR DESCRIPTION
@lukaszgryglicki, verify the following name conventions.

URL: https://github.com/kubernetes/k8s.io
Flat Path:  /home/pratikkaranje/.perceval/repositories/kubernetes-k8s.io

URL: https://github.com/kubernetes/kubernetes
Flat Path:  /home/pratikkaranje/.perceval/repositories/kubernetes-kubernetes

URL: https://github.com/kubernetes/community
Flat Path:  /home/pratikkaranje/.perceval/repositories/kubernetes-community

URL: https://github.com/kubernetes/minikube
Flat Path:  /home/pratikkaranje/.perceval/repositories/kubernetes-minikube

URL: https://github.com/kubernetes/kubectl
Flat Path:  /home/pratikkaranje/.perceval/repositories/kubernetes-kubectl

URL: https://github.com/kubernetes/kube-state-metrics
Flat Path:  /home/pratikkaranje/.perceval/repositories/kubernetes-kube-state-metrics

URL: https://github.com/ramitsurana/awesome-kubernetes
Flat Path:  /home/pratikkaranje/.perceval/repositories/ramitsurana-awesome-kubernetes

URL: https://github.com/kubernetes/examples
Flat Path:  /home/pratikkaranje/.perceval/repositories/kubernetes-examples

URL: https://github.com/kubernetes/dashboard
Flat Path:  /home/pratikkaranje/.perceval/repositories/kubernetes-dashboard

URL: https://github.com/kubernetes/kops
Flat Path:  /home/pratikkaranje/.perceval/repositories/kubernetes-kops