### PR TITLE
dads config fix

### DIFF
--- a/sources/cmd/syncdatasources/syncdatasources.go
+++ b/sources/cmd/syncdatasources/syncdatasources.go
@@ -4270,6 +4270,7 @@ func p2oConfig2dadsConfig(c []lib.MultiConfig, ds string) (oc []lib.MultiConfig,
 		// fmt.Printf("p2oConfig2dadsConfig: check for DADS %+v --> %v\n", c, dads)
 	}
 	if !all && !dads {
+		oc = c
 		return
 	}
 	env = make(map[string]string)


### PR DESCRIPTION
When dads is not configured, `p2oConfig2dadsConfig` returns an empty array. Added one liner to return original config array in this case. 
This currently affects dads enabled datasources because the configs are not added to the p2o commands