### PR TITLE
Fix the JSON generated for jenkins

### DIFF
--- a/sources/cmd/syncdatasources/syncdatasources.go
+++ b/sources/cmd/syncdatasources/syncdatasources.go
@@ -4363,7 +4363,8 @@ func p2oEndpoint2dadsEndpoint(e []string, ds string, dads bool, idxSlug string, 
 		if err != nil {
 			lib.Fatalf("p2oEndpoint2dadsEndpoint: Error in Jenkins buildservers: DS %s", ds)
 		}
-		env[prefix+"JENKINS_JSON"] = string(data)
+		// wrap JSON with single quote for da-ds Unmarshal
+		env[prefix+"JENKINS_JSON"] = fmt.Sprintf("'%s'", string(data))
 	default:
 		lib.Fatalf("p2oEndpoint2dadsEndpoint: DS%s not (yet) supported", ds)
 	}


### PR DESCRIPTION
da-ds is not able to unmarshal Jenkins JSON because of the following issue.

The following JSON variable is being used by da-ds.
`DA_JENKINS_JENKINS_JSON=[{"url":"random_jenkins_url.com","project":"random_project","index":"random_jenkins_index"}]`

In da-ds, when the JSON variable looked upon before the unmarshal, it looks like this.
`[{url:random_jenkins_url.com,project:random_project,index:random_jenkins_index}]`
where the quotes are omitted automatically, might be due to the exported variable is not wrapped up in eighter single or double quote. 

Which results in the following error in da-ds during unmarshal.
`Error: '[]*jenkins.BuildServer: jenkins.BuildServer.readFieldHash: expect ", but found u, error found in #3 byte of ...|[{url:https:/|..., bigger context ...|[{url:random_jenkins_url.com,project:random_project,index:sds-l|...`

ref: https://unix.stackexchange.com/questions/16303/what-is-the-significance-of-single-and-double-quotes-in-environment-variables 
From the above reference and after running tests, a single quote on either side of the exported JSON fixes the issue. Single quoted exports assign the string to the variable as it is without any substitution or changes.

