### PR TITLE
Jenkins JSON fix: Remove the single quotes

### DIFF
--- a/sources/cmd/syncdatasources/syncdatasources.go
+++ b/sources/cmd/syncdatasources/syncdatasources.go
@@ -4364,7 +4364,7 @@ func p2oEndpoint2dadsEndpoint(e []string, ds string, dads bool, idxSlug string, 
 			lib.Fatalf("p2oEndpoint2dadsEndpoint: Error in Jenkins buildservers: DS %s", ds)
 		}
 		// wrap JSON with single quote for da-ds Unmarshal
-		env[prefix+"JENKINS_JSON"] = fmt.Sprintf("'%s'", string(data))
+		env[prefix+"JENKINS_JSON"] = fmt.Sprintf("%s", string(data))
 	default:
 		lib.Fatalf("p2oEndpoint2dadsEndpoint: DS%s not (yet) supported", ds)
 	}


### PR DESCRIPTION
as SDS uses cmd.Env, we need not to add the single quotes. When tested with the dronecode.yaml, with this fix, following is the log successful log generated by the SDS.

```
2021-01-12 16:04:22: 1 Tasks, 1 data source types: jenkins
2021-01-12 16:04:23: Determining running order for 1 tasks
2021-01-12 16:04:23: Determined running order for 1 tasks
2021-01-12 16:04:24: Affiliations mode: false
2021-01-12 16:04:24: Processing 1 tasks using MT24 version (affiliations mode: false)
2021-01-12 16:04:24: Pass (affiliations: false) finished in 535.075624ms (excluding pending 1 threads)
2021-01-12 16:04:25: Processing:
2021-01-12 16:04:25: 555.214333ms: junkins:jenkins / dronecode:http://ci.px4.io
2021-01-12 16:04:25: Processed 0/2 (0.00%), failed: 0 (0.00%)
2021-01-12 16:04:26: Data source: jenkins, Processed 0/2 (0.00%), failed: 0 (0.00%)
2021-01-12 16:04:26: Fixture: junkins, Processed 0/2 (0.00%), failed: 0 (0.00%)
2021-01-12 16:04:26: Processed 0/2 (0.00%), failed: 0 (0.00%)
2021-01-12 16:04:27: Affiliations mode: true
2021-01-12 16:04:27: Processing 1 tasks using MT24 version (affiliations mode: true)
2021-01-12 16:04:27: Pass (affiliations: true) finished in 596.400889ms (excluding pending 2 threads)
2021-01-12 16:04:27: Processing:
2021-01-12 16:04:28: 536.897659ms: junkins:jenkins / dronecode:http://ci.px4.io
2021-01-12 16:04:28: Processed 0/2 (0.00%), failed: 0 (0.00%)
2021-01-12 16:04:28: Data source: jenkins, Processed 0/2 (0.00%), failed: 0 (0.00%)
2021-01-12 16:04:29: Fixture: junkins, Processed 0/2 (0.00%), failed: 0 (0.00%)
2021-01-12 16:04:29: Processed 0/2 (0.00%), failed: 0 (0.00%)
2021-01-12 16:04:29: Final 2 threads join
2021-01-12 16:05:06: Pass (threads join) finished in 36.754074481s
2021-01-12 16:05:06: Longest running tasks (finished):
2021-01-12 16:05:07: #1) 37.958748922s: DA_DS=jenkins DA_JENKINS_DADS=true DA_JENKINS_DB_HOST=[redacted] DA_JENKINS_DB_NAME=[redacted] DA_JENKINS_DB_PASS=[redacted] DA_JENKINS_DB_PORT=[redacted] DA_JENKINS_DB_USER=[redacted] DA_JENKINS_DELAY= DA_JENKINS_ENRICH=1 DA_JENKINS_ES_BULK_SIZE=500 DA_JENKINS_ES_SCROLL_SIZE=500 DA_JENKINS_ES_SCROLL_WAIT=2700s DA_JENKINS_ES_URL=[redacted] DA_JENKINS_FORCE_FULL=1 DA_JENKINS_GAP_URL= DA_JENKINS_HTTP_TIMEOUT=60s DA_JENKINS_JENKINS_JSON=[{"url":"http://ci.px4.io","project":"dronecode","index":"sds-junkins-jenkins"}] DA_JENKINS_NO_INCREMENTAL=1 DA_JENKINS_NO_RAW=1 DA_JENKINS_PROJECT_SLUG=junkins DA_JENKINS_RAW_INDEX=sds-junkins-jenkins-raw DA_JENKINS_REFRESH_AFFS=1 DA_JENKINS_RETRIES= DA_JENKINS_RICH_INDEX=sds-junkins-jenkins PROJECT_SLUG=junkins junkins:jenkins / dronecode:http://ci.px4.io [dads --bugzilla-project dronecode --bugzilla-fetch-size  --bugzilla-enrich-size  --bugzilla-origin http://ci.px4.io --bugzilla-do-fetch  --bugzilla-do-enrich ]: succeeded
2021-01-12 16:05:07: Processed 2/2 (100.00%), failed: 0 (0.00%)
2021-01-12 16:05:08: Skipped tasks: 0
2021-01-12 16:05:08: Sync time: 51.706535121s
```