### PR TITLE
skip ghost user review data

### DIFF
--- a/docker-images/base/patch/elk-github-reviews-data.py.diff
+++ b/docker-images/base/patch/elk-github-reviews-data.py.diff
@@ -9,6 +9,10 @@ index 5aae3bce..f28da00e 100644
 +        rich_pr['reviewer_data'] = list()
 +        reviews_data = pull_request.get('reviews_data', list())
 +        for review in reviews_data:
++            user_login = review.get('user_data', {}).get('login')
++            if not user_login:
++               continue
++
 +            rich_pr['reviewer_data'].append({
 +                'review_author_association': review.get('author_association', None),
 +                'review_comment': review.get('body', None),


### PR DESCRIPTION
Scope:
we are currently running into the error below especially for cntt because the gihub user deleted their account.
[More on GitHub ghost user](https://docs.github.com/en/github/setting-up-and-managing-your-github-user-account/deleting-your-user-account)
```
2021-02-26 17:04:40,857 Missing user info for https://github.com/cntt-n/CNTT/pull/3#pullrequestreview-251594340
2021-02-26 17:24:09,896 [github] Done collection for https://github.com/cntt-n/CNTT
2021-02-26 17:24:09,899 Backend feed completed
2021-02-26 17:24:17,377 Error enriching raw from github (https://github.com/cntt-n/CNTT): 'NoneType' object has no attribute 'get'
Traceback (most recent call last):
  File "/repos/grimoirelab-elk/grimoire_elk/elk.py", line 531, in enrich_backend
    enrich_count = enrich_items(ocean_backend, enrich_backend)
  File "/repos/grimoirelab-elk/grimoire_elk/elk.py", line 319, in enrich_items
    total = enrich_backend.enrich_items(ocean_backend)
  File "/repos/grimoirelab-elk/grimoire_elk/enriched/enrich.py", line 389, in enrich_items
    rich_item = self.get_rich_item(item)
  File "/repos/grimoirelab-elk/grimoire_elk/enriched/enrich.py", line 93, in decorator
    eitem = func(self, *args, **kwargs)
  File "/repos/grimoirelab-elk/grimoire_elk/enriched/github.py", line 223, in get_rich_item
    rich_item = self.__get_rich_pull(item)
  File "/repos/grimoirelab-elk/grimoire_elk/enriched/github.py", line 505, in __get_rich_pull
    'review_user_login': review.get('user_data', {}).get('login'),
AttributeError: 'NoneType' object has no attribute 'get'
2021-02-26 17:24:17,398 [github] Done enrichment for https://github.com/cntt-n/CNTT
2021-02-26 17:24:17,399 Enrich backend completed
2021-02-26 17:24:17,399 Finished in 27.33 min
```

My fix is to skip reviews by the ghost user since we aren't getting any data about this user from GitHub.