### PR TITLE
Add owner name to dockerhub endpoints

### DIFF
--- a/sources/cmd/syncdatasources/syncdatasources.go
+++ b/sources/cmd/syncdatasources/syncdatasources.go
@@ -838,7 +838,7 @@ func postprocessFixture(igctx context.Context, igc []*github.Client, ctx *lib.Ct
 					fixture.DataSources[i].Endpoints = append(
 						fixture.DataSources[i].Endpoints,
 						lib.Endpoint{
-							Name:              repo,
+							Name:              fmt.Sprintf("%s %s", dockerhubOwner, repo),
 							Project:           prj,
 							ProjectP2O:        p2o,
 							ProjectNoOrigin:   pno,


### PR DESCRIPTION
sds is panicing because the function p2oEndpoint2dadsEndpoint for dockerhub endpoints expects 2 items in the array: **the owner** and **the repo**. 
Currently, the dockerhub_org functionality only returns the repo name as the endpoint.

* Fix add owner to the endpoint name for dockerhub endpoints

Signed-off-by: Bammeke Michael <mike_bammeke@yahoo.com>